### PR TITLE
build: make addon building use --loglevel=silent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ CI_NATIVE_SUITES := addons addons-napi
 CI_JS_SUITES := abort async-hooks doctool inspector known_issues message parallel pseudo-tty sequential
 
 # Build and test addons without building anything else
-test-ci-native: LOGLEVEL := info
+test-ci-native: LOGLEVEL := silent
 test-ci-native: | test/addons/.buildstamp test/addons-napi/.buildstamp
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
@@ -357,7 +357,7 @@ test-ci-js: | clear-stalled
 		echo $${PS_OUT} | xargs kill; exit 1; \
 	fi
 
-test-ci: LOGLEVEL := info
+test-ci: LOGLEVEL := silent
 test-ci: | clear-stalled build-addons build-addons-napi
 	out/Release/cctest --gtest_output=tap:cctest.tap
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \


### PR DESCRIPTION
The verbose output from `node-gyp` is eating an unhelpful amount
of our Travis CI log limit right now, hiding real test output.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

build