### PR TITLE
ci: use one-line status report instead of TAP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ test-ci-js: | clear-stalled
 test-ci: LOGLEVEL := silent
 test-ci: | clear-stalled build-addons build-addons-napi
 	out/Release/cctest --gtest_output=tap:cctest.tap
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p oneline \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES)
 	# Clean up any leftover processes, error if found.

--- a/tools/test.py
+++ b/tools/test.py
@@ -454,12 +454,29 @@ class MonochromeProgressIndicator(CompactProgressIndicator):
     print ("\r" + (" " * last_line_length) + "\r"),
 
 
+class OneLineProgressIndicator(CompactProgressIndicator):
+
+  def __init__(self, cases, flaky_tests_mode):
+    templates = {
+      'status_line': "[%(mins)02i:%(secs)02i|%%%(remaining) 4d|+%(passed) 4d|-%(failed) 4d]: %(test)s",
+      'stdout': '%s',
+      'stderr': '%s',
+      'clear': lambda: "\n",
+      'max_length': 78
+    }
+    super(OneLineProgressIndicator, self).__init__(cases, flaky_tests_mode, templates)
+
+  def ClearLine(self, last_line_length):
+    print ("\n"),
+
+
 PROGRESS_INDICATORS = {
   'verbose': VerboseProgressIndicator,
   'dots': DotsProgressIndicator,
   'color': ColorProgressIndicator,
   'tap': TapProgressIndicator,
   'mono': MonochromeProgressIndicator,
+  'oneline': OneLineProgressIndicator,
   'deopts': DeoptsCheckProgressIndicator
 }
 


### PR DESCRIPTION
This should be enough to bring the CI log under the Travis maximum of 10.000 lines while not losing useful information.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

ci