### PR TITLE
timers: warn on overflowed timeout duration

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -405,6 +405,9 @@ exports.enroll = function(item, msecs) {
 
   // Ensure that msecs fits into signed int32
   if (msecs > TIMEOUT_MAX) {
+    process.emitWarning(`${msecs} does not fit into a 32-bit signed integer.` +
+                        `\nTimer duration was truncated to ${TIMEOUT_MAX}.`,
+                        'TimeoutOverflowWarning');
     msecs = TIMEOUT_MAX;
   }
 
@@ -449,8 +452,15 @@ exports.setTimeout = setTimeout;
 
 function createSingleTimeout(callback, after, args) {
   after *= 1; // coalesce to number or NaN
-  if (!(after >= 1 && after <= TIMEOUT_MAX))
+  if (!(after >= 1 && after <= TIMEOUT_MAX)) {
+    if (after > TIMEOUT_MAX) {
+      process.emitWarning(`${after} does not fit into` +
+                          ' a 32-bit signed integer.' +
+                          '\nTimeout duration was set to 1.',
+                          'TimeoutOverflowWarning');
+    }
     after = 1; // schedule on next tick, follows browser behavior
+  }
 
   var timer = new Timeout(after, callback, args);
   if (process.domain)
@@ -538,8 +548,15 @@ exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
 
 function createRepeatTimeout(callback, repeat, args) {
   repeat *= 1; // coalesce to number or NaN
-  if (!(repeat >= 1 && repeat <= TIMEOUT_MAX))
+  if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
+    if (repeat > TIMEOUT_MAX) {
+      process.emitWarning(`${repeat} does not fit into` +
+                          ' a 32-bit signed integer.' +
+                          '\nInterval duration was set to 1.',
+                          'TimeoutOverflowWarning');
+    }
     repeat = 1; // schedule on next tick, follows browser behavior
+  }
 
   var timer = new Timeout(repeat, callback, args);
   timer._repeat = repeat;

--- a/test/parallel/test-timers-max-duration-warning.js
+++ b/test/parallel/test-timers-max-duration-warning.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const timers = require('timers');
+
+const OVERFLOW = Math.pow(2, 31); // TIMEOUT_MAX is 2^31-1
+
+function timerNotCanceled() {
+  common.fail('Timer should be canceled');
+}
+
+process.on('warning', common.mustCall((warning) => {
+  const lines = warning.message.split('\n');
+
+  assert.strictEqual(warning.name, 'TimeoutOverflowWarning');
+  assert.strictEqual(lines[0], `${OVERFLOW} does not fit into a 32-bit signed` +
+                               ' integer.');
+  assert.strictEqual(lines.length, 2);
+}, 3));
+
+
+{
+  const timeout = setTimeout(timerNotCanceled, OVERFLOW);
+  clearTimeout(timeout);
+}
+
+{
+  const interval = setInterval(timerNotCanceled, OVERFLOW);
+  clearInterval(interval);
+}
+
+{
+  const timer = {
+    _onTimeout: timerNotCanceled
+  };
+  timers.enroll(timer, OVERFLOW);
+  timers.active(timer);
+  timers.unenroll(timer);
+}


### PR DESCRIPTION
Previously there wasn't any clear indicator when you hit the overflow
other than possibly unexpected behavior, and I think emitting a warning
may be appropriate.

While it may be viable to allow the use of 64bit numbers in `enroll()`, browser `setTimeout`/`setInterval` just coerces it to `1`, which we've been roughly following so far.

I previously had a PR for this at https://github.com/nodejs/node/pull/6956 but I didn't really take it anywhere at the time.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers