### PR TITLE
ci: run the linter from travis with every build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,26 @@
 language: cpp
 compiler:
   - clang
-os:
-  - linux
-  - osx
 sudo: false
 cache: ccache
+matrix:
+  include:
+    - os: linux
+      node_js: "8"
+      script:
+        - NODE=$(which node) make lint-ci
+    - os: linux
+      install:
+        - ./configure
+        - make -j2 V=
+      script:
+        - make -j2 test-ci
+    - os: osx
+      install:
+        - ./configure
+        - make -j2 V=
+      script:
+        - make -j2 test-ci
 before_install:
   - export HOMEBREW_NO_AUTO_UPDATE=1 # work around https://github.com/travis-ci/travis-ci/issues/7456
   - if [ $TRAVIS_OS_NAME = osx ]; then brew install ccache; fi
@@ -13,8 +28,3 @@ before_install:
   - export CXX="ccache clang++ -Qunused-arguments"
   - export CC="ccache clang -Qunused-arguments"
   - export JOBS=2
-install:
-  - ./configure
-  - make -j2 V=
-script:
-  - make -j2 test-ci


### PR DESCRIPTION
It'd be nice to have it run as a separate task, but I think this should
work for now.

Refs: https://github.com/ayojs/ayo/pull/71

cc @addaleax 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
ci