### PR TITLE
src: use cleanup hooks to tear down BaseObjects (workers preparation)

### DIFF
--- a/src/base-object-inl.h
+++ b/src/base-object-inl.h
@@ -41,11 +41,13 @@ inline BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> handle)
   // nullptr in case it's accessed by the user before construction is complete.
   if (handle->InternalFieldCount() > 0)
     handle->SetAlignedPointerInInternalField(0, nullptr);
+  env_->AddCleanupHook(DeleteMe, static_cast<void*>(this));
 }
 
 
 inline BaseObject::~BaseObject() {
-  CHECK(persistent_handle_.IsEmpty());
+  env_->RemoveCleanupHook(DeleteMe, static_cast<void*>(this));
+  persistent_handle_.Reset();
 }
 
 
@@ -61,6 +63,12 @@ inline v8::Local<v8::Object> BaseObject::object() {
 
 inline Environment* BaseObject::env() const {
   return env_;
+}
+
+
+inline void BaseObject::DeleteMe(void* data) {
+  BaseObject* self = static_cast<BaseObject*>(data);
+  delete self;
 }
 
 

--- a/src/base-object.h
+++ b/src/base-object.h
@@ -64,6 +64,7 @@ class BaseObject {
   template <typename Type>
   static inline void WeakCallback(
       const v8::WeakCallbackInfo<Type>& data);
+  static inline void DeleteMe(void* data);
 
   v8::Persistent<v8::Object> persistent_handle_;
   Environment* env_;


### PR DESCRIPTION
Clean up after `BaseObject` instances when the `Environment` is being shut down. This takes care of closing non-libuv resources like `zlib` instances, which do not require asynchronous shutdown.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below. Opening a Pull Request means that you agree to abide by
our Code of Conduct which can be found at:
https://github.com/ayojs/ayo/blob/latest/CODE_OF_CONDUCT.md

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)
