### PR TITLE
src: prepare v8 platform for multi-isolate support (workers preparation)

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -38,41 +38,9 @@
 
 namespace node {
 
-inline IsolateData::IsolateData(v8::Isolate* isolate, uv_loop_t* event_loop,
-                                uint32_t* zero_fill_field) :
-
-// Create string and private symbol properties as internalized one byte strings.
-//
-// Internalized because it makes property lookups a little faster and because
-// the string is created in the old space straight away.  It's going to end up
-// in the old space sooner or later anyway but now it doesn't go through
-// v8::Eternal's new space handling first.
-//
-// One byte because our strings are ASCII and we can safely skip V8's UTF-8
-// decoding step.  It's a one-time cost, but why pay it when you don't have to?
-#define V(PropertyName, StringValue)                                          \
-    PropertyName ## _(                                                        \
-        isolate,                                                              \
-        v8::Private::New(                                                     \
-            isolate,                                                          \
-            v8::String::NewFromOneByte(                                       \
-                isolate,                                                      \
-                reinterpret_cast<const uint8_t*>(StringValue),                \
-                v8::NewStringType::kInternalized,                             \
-                sizeof(StringValue) - 1).ToLocalChecked())),
-  PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
-#undef V
-#define V(PropertyName, StringValue)                                          \
-    PropertyName ## _(                                                        \
-        isolate,                                                              \
-        v8::String::NewFromOneByte(                                           \
-            isolate,                                                          \
-            reinterpret_cast<const uint8_t*>(StringValue),                    \
-            v8::NewStringType::kInternalized,                                 \
-            sizeof(StringValue) - 1).ToLocalChecked()),
-    PER_ISOLATE_STRING_PROPERTIES(V)
-#undef V
-    event_loop_(event_loop), zero_fill_field_(zero_fill_field) {}
+inline v8::Isolate* IsolateData::isolate() const {
+  return isolate_;
+}
 
 inline uv_loop_t* IsolateData::event_loop() const {
   return event_loop_;
@@ -80,6 +48,10 @@ inline uv_loop_t* IsolateData::event_loop() const {
 
 inline uint32_t* IsolateData::zero_fill_field() const {
   return zero_fill_field_;
+}
+
+inline MultiIsolatePlatform* IsolateData::platform() const {
+  return platform_;
 }
 
 inline Environment::AsyncHooks::AsyncHooks(v8::Isolate* isolate)

--- a/src/env.cc
+++ b/src/env.cc
@@ -2,6 +2,7 @@
 #include "async-wrap.h"
 #include "v8-profiler.h"
 #include "req-wrap-inl.h"
+#include "node_platform.h"
 
 #if defined(_MSC_VER)
 #define getpid GetCurrentProcessId
@@ -17,10 +18,62 @@ namespace node {
 using v8::Context;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Isolate;
 using v8::Local;
 using v8::Message;
+using v8::Private;
 using v8::StackFrame;
 using v8::StackTrace;
+using v8::String;
+
+IsolateData::IsolateData(Isolate* isolate,
+                         uv_loop_t* event_loop,
+                         MultiIsolatePlatform* platform,
+                         uint32_t* zero_fill_field) :
+
+// Create string and private symbol properties as internalized one byte strings.
+//
+// Internalized because it makes property lookups a little faster and because
+// the string is created in the old space straight away.  It's going to end up
+// in the old space sooner or later anyway but now it doesn't go through
+// v8::Eternal's new space handling first.
+//
+// One byte because our strings are ASCII and we can safely skip V8's UTF-8
+// decoding step.  It's a one-time cost, but why pay it when you don't have to?
+#define V(PropertyName, StringValue)                                          \
+    PropertyName ## _(                                                        \
+        isolate,                                                              \
+        Private::New(                                                         \
+            isolate,                                                          \
+            String::NewFromOneByte(                                           \
+                isolate,                                                      \
+                reinterpret_cast<const uint8_t*>(StringValue),                \
+                v8::NewStringType::kInternalized,                             \
+                sizeof(StringValue) - 1).ToLocalChecked())),
+  PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
+#undef V
+#define V(PropertyName, StringValue)                                          \
+    PropertyName ## _(                                                        \
+        isolate,                                                              \
+        String::NewFromOneByte(                                               \
+            isolate,                                                          \
+            reinterpret_cast<const uint8_t*>(StringValue),                    \
+            v8::NewStringType::kInternalized,                                 \
+            sizeof(StringValue) - 1).ToLocalChecked()),
+    PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+    isolate_(isolate),
+    event_loop_(event_loop),
+    zero_fill_field_(zero_fill_field),
+    platform_(platform) {
+  if (platform_ != nullptr)
+    platform_->RegisterIsolate(this, event_loop);
+}
+
+IsolateData::~IsolateData() {
+  if (platform_ != nullptr)
+    platform_->UnregisterIsolate(this);
+}
 
 void Environment::Start(int argc,
                         const char* const* argv,

--- a/src/env.h
+++ b/src/env.h
@@ -338,10 +338,13 @@ struct node_async_ids {
 
 class IsolateData {
  public:
-  inline IsolateData(v8::Isolate* isolate, uv_loop_t* event_loop,
-                     uint32_t* zero_fill_field = nullptr);
+  IsolateData(v8::Isolate* isolate, uv_loop_t* event_loop,
+              MultiIsolatePlatform* platform = nullptr,
+              uint32_t* zero_fill_field = nullptr);
+  ~IsolateData();
   inline uv_loop_t* event_loop() const;
   inline uint32_t* zero_fill_field() const;
+  inline MultiIsolatePlatform* platform() const;
 
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
 #define VS(PropertyName, StringValue) V(v8::String, PropertyName)
@@ -354,6 +357,7 @@ class IsolateData {
 #undef VP
 
   std::unordered_map<nghttp2_rcbuf*, v8::Eternal<v8::String>> http2_static_strs;
+  inline v8::Isolate* isolate() const;
 
  private:
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
@@ -366,8 +370,10 @@ class IsolateData {
 #undef VS
 #undef VP
 
+  v8::Isolate* const isolate_;
   uv_loop_t* const event_loop_;
   uint32_t* const zero_fill_field_;
+  MultiIsolatePlatform* platform_;
 
   DISALLOW_COPY_AND_ASSIGN(IsolateData);
 };

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -489,7 +489,7 @@ class NodeInspectorClient : public V8InspectorClient {
     terminated_ = false;
     running_nested_loop_ = true;
     while (!terminated_ && channel_->waitForFrontendMessage()) {
-      platform_->FlushForegroundTasksInternal();
+      platform_->FlushForegroundTasks(env_->isolate());
     }
     terminated_ = false;
     running_nested_loop_ = false;

--- a/src/node.cc
+++ b/src/node.cc
@@ -261,10 +261,10 @@ node::DebugOptions debug_options;
 
 static struct {
 #if NODE_USE_V8_PLATFORM
-  void Initialize(int thread_pool_size, uv_loop_t* loop) {
+  void Initialize(int thread_pool_size) {
     tracing_agent_ =
         trace_enabled ? new tracing::Agent() : nullptr;
-    platform_ = new NodePlatform(thread_pool_size, loop,
+    platform_ = new NodePlatform(thread_pool_size,
         trace_enabled ? tracing_agent_->GetTracingController() : nullptr);
     V8::InitializePlatform(platform_);
     tracing::TraceEventHelper::SetTracingController(
@@ -279,8 +279,8 @@ static struct {
     tracing_agent_ = nullptr;
   }
 
-  void DrainVMTasks() {
-    platform_->DrainBackgroundTasks();
+  void DrainVMTasks(Isolate* isolate) {
+    platform_->DrainBackgroundTasks(isolate);
   }
 
 #if HAVE_INSPECTOR
@@ -305,12 +305,16 @@ static struct {
     tracing_agent_->Stop();
   }
 
+  NodePlatform* Platform() {
+    return platform_;
+  }
+
   tracing::Agent* tracing_agent_;
   NodePlatform* platform_;
 #else  // !NODE_USE_V8_PLATFORM
-  void Initialize(int thread_pool_size, uv_loop_t* loop) {}
+  void Initialize(int thread_pool_size) {}
   void Dispose() {}
-  void DrainVMTasks() {}
+  void DrainVMTasks(Isolate* isolate) {}
   bool StartInspector(Environment *env, const char* script_path,
                       const node::DebugOptions& options) {
     env->ThrowError("Node compiled with NODE_USE_V8_PLATFORM=0");
@@ -322,6 +326,10 @@ static struct {
                     "so event tracing is not available.\n");
   }
   void StopTracingAgent() {}
+
+  NodePlatform* Platform() {
+    return nullptr;
+  }
 #endif  // !NODE_USE_V8_PLATFORM
 
 #if !NODE_USE_V8_PLATFORM || !HAVE_INSPECTOR
@@ -4672,7 +4680,14 @@ int EmitExit(Environment* env) {
 
 
 IsolateData* CreateIsolateData(Isolate* isolate, uv_loop_t* loop) {
-  return new IsolateData(isolate, loop);
+  return new IsolateData(isolate, loop, nullptr);
+}
+
+IsolateData* CreateIsolateData(
+    Isolate* isolate,
+    uv_loop_t* loop,
+    MultiIsolatePlatform* platform) {
+  return new IsolateData(isolate, loop, platform);
 }
 
 
@@ -4753,7 +4768,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
     do {
       uv_run(env.event_loop(), UV_RUN_DEFAULT);
 
-      v8_platform.DrainVMTasks();
+      v8_platform.DrainVMTasks(isolate);
 
       more = uv_loop_alive(env.event_loop());
       if (more)
@@ -4777,7 +4792,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   RunAtExit(&env);
   uv_key_delete(&thread_local_env);
 
-  v8_platform.DrainVMTasks();
+  v8_platform.DrainVMTasks(isolate);
   WaitForInspectorDisconnect(&env);
 #if defined(LEAK_SANITIZER)
   __lsan_do_leak_check();
@@ -4820,7 +4835,11 @@ inline int Start(uv_loop_t* event_loop,
     Locker locker(isolate);
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
-    IsolateData isolate_data(isolate, event_loop, allocator.zero_fill_field());
+    IsolateData isolate_data(
+        isolate,
+        event_loop,
+        v8_platform.Platform(),
+        allocator.zero_fill_field());
     exit_code = Start(isolate, &isolate_data, argc, argv, exec_argc, exec_argv);
   }
 
@@ -4867,7 +4886,7 @@ int Start(int argc, char** argv) {
   V8::SetEntropySource(crypto::EntropySource);
 #endif  // HAVE_OPENSSL
 
-  v8_platform.Initialize(v8_thread_pool_size, uv_default_loop());
+  v8_platform.Initialize(v8_thread_pool_size);
   // Enable tracing when argv has --trace-events-enabled.
   if (trace_enabled) {
     fprintf(stderr, "Warning: Trace event is an experimental feature "

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -73,6 +73,8 @@ class NodeTestFixture : public ::testing::Test {
  public:
   static uv_loop_t* CurrentLoop() { return &current_loop; }
 
+  node::MultiIsolatePlatform* Platform() const { return platform_; }
+
  protected:
   v8::Isolate::CreateParams params_;
   ArrayBufferAllocator allocator_;
@@ -84,7 +86,7 @@ class NodeTestFixture : public ::testing::Test {
 
   virtual void SetUp() {
     CHECK_EQ(0, uv_loop_init(&current_loop));
-    platform_ = new node::NodePlatform(8, &current_loop, nullptr);
+    platform_ = new node::NodePlatform(8, nullptr);
     v8::V8::InitializePlatform(platform_);
     v8::V8::Initialize();
     params_.array_buffer_allocator = &allocator_;

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -26,11 +26,13 @@ class EnvironmentTest : public NodeTestFixture {
    public:
     Env(const v8::HandleScope& handle_scope,
         v8::Isolate* isolate,
-        const Argv& argv) {
+        const Argv& argv,
+        NodeTestFixture* test_fixture) {
       context_ = v8::Context::New(isolate);
       CHECK(!context_.IsEmpty());
       isolate_data_ = CreateIsolateData(isolate,
-                                        NodeTestFixture::CurrentLoop());
+                                        NodeTestFixture::CurrentLoop(),
+                                        test_fixture->Platform());
       CHECK_NE(nullptr, isolate_data_);
       environment_ = CreateEnvironment(isolate_data_,
                                        context_,
@@ -66,7 +68,7 @@ class EnvironmentTest : public NodeTestFixture {
 TEST_F(EnvironmentTest, AtExitWithEnvironment) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env {handle_scope, isolate_, argv};
+  Env env {handle_scope, isolate_, argv, this};
 
   AtExit(*env, at_exit_callback1);
   RunAtExit(*env);
@@ -76,7 +78,7 @@ TEST_F(EnvironmentTest, AtExitWithEnvironment) {
 TEST_F(EnvironmentTest, AtExitWithArgument) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env {handle_scope, isolate_, argv};
+  Env env {handle_scope, isolate_, argv, this};
 
   std::string arg{"some args"};
   AtExit(*env, at_exit_callback1, static_cast<void*>(&arg));
@@ -87,8 +89,8 @@ TEST_F(EnvironmentTest, AtExitWithArgument) {
 TEST_F(EnvironmentTest, MultipleEnvironmentsPerIsolate) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env1 {handle_scope, isolate_, argv};
-  Env env2 {handle_scope, isolate_, argv};
+  Env env1 {handle_scope, isolate_, argv, this};
+  Env env2 {handle_scope, isolate_, argv, this};
 
   AtExit(*env1, at_exit_callback1);
   AtExit(*env2, at_exit_callback2);


### PR DESCRIPTION
This splits the task queue used for asynchronous tasks scheduled by V8 in per-isolate queues, so that multiple threads can be supported.



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below. Opening a Pull Request means that you agree to abide by
our Code of Conduct which can be found at:
https://github.com/ayojs/ayo/blob/latest/CODE_OF_CONDUCT.md

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)