### PR TITLE
src: add Env::profiler_idle_notifier_started() (workers preparation)

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -284,6 +284,7 @@ inline Environment::Environment(IsolateData* isolate_data,
                                 v8::Local<v8::Context> context)
     : isolate_(context->GetIsolate()),
       isolate_data_(isolate_data),
+      profiler_idle_notifier_started_(false),
       async_hooks_(context->GetIsolate()),
       timer_base_(uv_now(isolate_data->event_loop())),
       using_domains_(false),
@@ -335,6 +336,10 @@ inline Environment::~Environment() {
   delete http2_state_;
   delete[] fs_stats_field_array_;
   free(performance_state_);
+}
+
+inline bool Environment::profiler_idle_notifier_started() const {
+  return profiler_idle_notifier_started_;
 }
 
 inline v8::Isolate* Environment::isolate() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -111,6 +111,11 @@ void Environment::CleanupHandles() {
 }
 
 void Environment::StartProfilerIdleNotifier() {
+  if (profiler_idle_notifier_started_)
+    return;
+
+  profiler_idle_notifier_started_ = true;
+
   uv_prepare_start(&idle_prepare_handle_, [](uv_prepare_t* handle) {
     Environment* env = ContainerOf(&Environment::idle_prepare_handle_, handle);
     env->isolate()->GetCpuProfiler()->SetIdle(true);
@@ -123,6 +128,7 @@ void Environment::StartProfilerIdleNotifier() {
 }
 
 void Environment::StopProfilerIdleNotifier() {
+  profiler_idle_notifier_started_ = false;
   uv_prepare_stop(&idle_prepare_handle_);
   uv_check_stop(&idle_check_handle_);
 }

--- a/src/env.h
+++ b/src/env.h
@@ -543,6 +543,7 @@ class Environment {
 
   void StartProfilerIdleNotifier();
   void StopProfilerIdleNotifier();
+  inline bool profiler_idle_notifier_started() const;
 
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;
@@ -703,6 +704,7 @@ class Environment {
   uv_timer_t destroy_async_ids_timer_handle_;
   uv_prepare_t idle_prepare_handle_;
   uv_check_t idle_check_handle_;
+  bool profiler_idle_notifier_started_;
 
   AsyncHooks async_hooks_;
   DomainFlag domain_flag_;


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src