### PR TITLE
src: rename string id for `_onclose` to match (workers preparation)

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -113,7 +113,8 @@ class ModuleWrap;
   V(channel_string, "channel")                                                \
   V(constants_string, "constants")                                            \
   V(oncertcb_string, "oncertcb")                                              \
-  V(onclose_string, "_onclose")                                               \
+  V(_onclose_string, "_onclose")                                              \
+  V(onclose_string, "onclose")                                                \
   V(code_string, "code")                                                      \
   V(configurable_string, "configurable")                                      \
   V(cwd_string, "cwd")                                                        \

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -79,7 +79,7 @@ void HandleWrap::Close(v8::Local<v8::Value> close_callback) {
   state_ = kClosing;
 
   if (!close_callback.IsEmpty() && close_callback->IsFunction()) {
-    object()->Set(env()->context(), env()->onclose_string(), close_callback)
+    object()->Set(env()->context(), env()->_onclose_string(), close_callback)
         .FromJust();
     state_ = kClosingWithCallback;
   }
@@ -132,7 +132,7 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   wrap->OnClose();
 
   if (have_close_callback)
-    wrap->MakeCallback(env->onclose_string(), 0, nullptr);
+    wrap->MakeCallback(env->_onclose_string(), 0, nullptr);
 
   ClearWrap(wrap->object());
   wrap->persistent().Reset();


### PR DESCRIPTION
This is just a tiny change that moves registers `'_onclose'` string under that name and introduces `'onclose'` for later use.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src