### PR TITLE
benchmark: port cluster/echo to worker

### DIFF
--- a/benchmark/fixtures/echo.worker.js
+++ b/benchmark/fixtures/echo.worker.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const worker = require('worker');
+
+worker.on('workerMessage', (msg) => {
+  worker.postMessage(msg);
+});

--- a/benchmark/worker/echo.js
+++ b/benchmark/worker/echo.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { Worker } = require('worker');
+const common = require('../common.js');
+const path = require('path');
+const bench = common.createBenchmark(main, {
+  workers: [1],
+  payload: ['string', 'object'],
+  sendsPerBroadcast: [1, 10],
+  n: [1e5]
+});
+
+const workerPath = path.resolve(__dirname, '..', 'fixtures', 'echo.worker.js');
+
+function main(conf) {
+  const n = +conf.n;
+  const workers = +conf.workers;
+  const sends = +conf.sendsPerBroadcast;
+  const expectedPerBroadcast = sends * workers;
+  var payload;
+  var readies = 0;
+  var broadcasts = 0;
+  var msgCount = 0;
+
+  switch (conf.payload) {
+    case 'string':
+      payload = 'hello world!';
+      break;
+    case 'object':
+      payload = { action: 'pewpewpew', powerLevel: 9001 };
+      break;
+    default:
+      throw new Error('Unsupported payload type');
+  }
+
+  const workerObjs = [];
+
+  for (var i = 0; i < workers; ++i) {
+    const worker = new Worker(workerPath);
+    workerObjs.push(worker);
+    worker.on('online', onOnline);
+    worker.on('message', onMessage);
+  }
+
+  function onOnline() {
+    if (++readies === workers) {
+      bench.start();
+      broadcast();
+    }
+  }
+
+  function broadcast() {
+    if (broadcasts++ === n) {
+      bench.end(n);
+      for (const worker of workerObjs) {
+        worker.unref();
+      }
+      return;
+    }
+    for (const worker of workerObjs) {
+      for (var i = 0; i < sends; ++i)
+        worker.postMessage(payload);
+    }
+  }
+
+  function onMessage() {
+    if (++msgCount === expectedPerBroadcast) {
+      msgCount = 0;
+      broadcast();
+    }
+  }
+}


### PR DESCRIPTION
```
$ ./ayo benchmark/cluster/echo.js
cluster/echo.js n=100000 sendsPerBroadcast=1 payload="string" workers=1: 26,709.154114687004
cluster/echo.js n=100000 sendsPerBroadcast=10 payload="string" workers=1: 15,936.350422945854
cluster/echo.js n=100000 sendsPerBroadcast=1 payload="object" workers=1: 20,778.85550744996
cluster/echo.js n=100000 sendsPerBroadcast=10 payload="object" workers=1: 10,912.260027807712
$ ./ayo benchmark/worker/echo.js
worker/echo.js n=100000 sendsPerBroadcast=1 payload="string" workers=1: 69,787.63926344117
worker/echo.js n=100000 sendsPerBroadcast=10 payload="string" workers=1: 32,544.630210444844
worker/echo.js n=100000 sendsPerBroadcast=1 payload="object" workers=1: 48,706.90345844702
worker/echo.js n=100000 sendsPerBroadcast=10 payload="object" workers=1: 18,088.639282621873
```

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

workers/benchmark