### PR TITLE
src: cancel pending delayed platform tasks on exit

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -289,6 +289,10 @@ static struct {
     platform_->DrainBackgroundTasks(isolate);
   }
 
+  void CancelVMTasks(Isolate* isolate) {
+    platform_->CancelPendingDelayedTasks(isolate);
+  }
+
 #if HAVE_INSPECTOR
   bool StartInspector(Environment *env, const char* script_path,
                       const node::DebugOptions& options) {
@@ -321,6 +325,7 @@ static struct {
   void Initialize(int thread_pool_size) {}
   void Dispose() {}
   void DrainVMTasks(Isolate* isolate) {}
+  void CancelVMTasks(Isolate* isolate) {}
   bool StartInspector(Environment *env, const char* script_path,
                       const node::DebugOptions& options) {
     env->ThrowError("Node compiled with NODE_USE_V8_PLATFORM=0");
@@ -4924,6 +4929,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   uv_key_delete(&thread_local_env);
 
   v8_platform.DrainVMTasks(isolate);
+  v8_platform.CancelVMTasks(isolate);
   WaitForInspectorDisconnect(&env);
 #if defined(LEAK_SANITIZER)
   __lsan_do_leak_check();

--- a/src/node.h
+++ b/src/node.h
@@ -214,6 +214,7 @@ class MultiIsolatePlatform : public v8::Platform {
  public:
   virtual ~MultiIsolatePlatform() { }
   virtual void DrainBackgroundTasks(v8::Isolate* isolate) = 0;
+  virtual void CancelPendingDelayedTasks(v8::Isolate* isolate) = 0;
 
   // These will be called by the `IsolateData` creation/destruction functions.
   virtual void RegisterIsolate(IsolateData* isolate_data,

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -300,6 +300,7 @@ void Worker::Run() {
         Isolate::DisallowJavascriptExecutionScope::THROW_ON_FAILURE);
 
     platform->DrainBackgroundTasks(isolate_);
+    platform->CancelPendingDelayedTasks(isolate_);
 
     // Grab the parent-to-child channel and render is unusable.
     MessagePort* child_port;


### PR DESCRIPTION
Worker threads need an event loop without active libuv handles in
order to shut down. One source of handles that was previously
not accounted for were delayed V8 tasks; these create timers
that would be standing in the way of clearing the event loop.

To solve this, keep track of the scheduled tasks in a list
and close their timer handles before the corresponding isolate/loop
is removed from the platform.

It is not clear from the V8 documentation what the expectation is
with respect to pending background tasks at the end of the
isolate lifetime; however, an alternative approach of executing
these scheduled tasks when flushing them led to an infinite loop
of tasks scheduling each other; so it seems safe to assume that
the behaviour implemented in this patch is at least acceptable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below. Opening a Pull Request means that you agree to abide by
our Code of Conduct which can be found at:
https://github.com/ayojs/ayo/blob/latest/CODE_OF_CONDUCT.md

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [½] tests and/or benchmarks are included (one of the HTTP tests doesn’t work in workers without it)
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/node_platform