### PR TITLE
doc: make linting pass for workers code

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1331,6 +1331,32 @@ entry types were found.
 
 Used when a given value is out of the accepted range.
 
+<a id="ERR_WORKER_DOMAIN"></a>
+### ERR_WORKER_DOMAIN
+
+Used when trying to access the `domain` module inside of a worker thread.
+
+<a id="ERR_WORKER_NEED_ABSOLUTE_PATH"></a>
+### ERR_WORKER_NEED_ABSOLUTE_PATH
+
+Used when the path for the main script of a worker is not an absolute path.
+
+<a id="ERR_WORKER_OUT_OF_MEMORY"></a>
+### ERR_WORKER_OUT_OF_MEMORY
+
+Used when a worker hits its memory limit.
+
+<a id="ERR_WORKER_UNSERIALIZABLE_ERROR"></a>
+### ERR_WORKER_UNSERIALIZABLE_ERROR
+
+Used when all attempts at serializing an uncaught exception from a fail.
+
+<a id="ERR_WORKER_UNSUPPORTED_EXTENSION"></a>
+### ERR_WORKER_UNSUPPORTED_EXTENSION
+
+Used when the pathname used for the main script of a worker has an
+unknown file extension.
+
 <a id="ERR_ZLIB_BINDING_CLOSED"></a>
 ### ERR_ZLIB_BINDING_CLOSED
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1349,7 +1349,7 @@ Used when a worker hits its memory limit.
 <a id="ERR_WORKER_UNSERIALIZABLE_ERROR"></a>
 ### ERR_WORKER_UNSERIALIZABLE_ERROR
 
-Used when all attempts at serializing an uncaught exception from a fail.
+Used when all attempts at serializing an uncaught exception from a worker fail.
 
 <a id="ERR_WORKER_UNSUPPORTED_EXTENSION"></a>
 ### ERR_WORKER_UNSUPPORTED_EXTENSION

--- a/doc/api/worker.md
+++ b/doc/api/worker.md
@@ -435,9 +435,7 @@ it is available as [`require('worker').threadId`][].
 [`worker.postMessage()`]: #worker_worker_postmessage_value_transferlist_1
 [`worker.on('message')`]: #worker_event_message_1
 [`worker.threadId`]: #worker_worker_threadid_1
-[`port.postMessage()`]: #worker_port_postmessage_value_transferlist
 [`port.on('message')`]: #worker_event_message
-[`process.exit()`]: process.html#process_process_exit
 [`process.exit()`]: process.html#process_process_exit
 [`process.abort()`]: process.html#process_process_abort
 [`process.chdir()`]: process.html#process_process_chdir_directory


### PR DESCRIPTION
Fix a couple of linter errors that come with stricter upstream linting (mostly missing documentation for codes).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

doc/workers