### PR TITLE
src: relax handling of write wrap during cleanup

### DIFF
--- a/src/req-wrap-inl.h
+++ b/src/req-wrap-inl.h
@@ -30,7 +30,6 @@ ReqWrap<T>::ReqWrap(Environment* env,
 template <typename T>
 ReqWrap<T>::~ReqWrap() {
   CHECK_EQ(req_.data, this);  // Assert that someone has called Dispatched().
-  CHECK_EQ(false, persistent().IsEmpty());
   persistent().Reset();
 }
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -159,6 +159,10 @@ void WriteWrap::Dispose() {
 }
 
 
+void WriteWrap::operator delete(void* ptr) {
+  static_cast<WriteWrap*>(ptr)->Dispose();
+}
+
 char* WriteWrap::Extra(size_t offset) {
   return reinterpret_cast<char*>(this) +
          ROUND_UP(sizeof(*this), kAlignSize) +


### PR DESCRIPTION
One of the HTTP2 tests that are being updated upstream in Node.js
leaves around a `WriteWrap` instance that is not passed over to libuv
and therefore can’t be cleaned up.

Address that issue by properly implementing `delete self;` for
`WriteWrap`s using the existing `Dispose()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below. Opening a Pull Request means that you agree to abide by
our Code of Conduct which can be found at:
https://github.com/ayojs/ayo/blob/latest/CODE_OF_CONDUCT.md

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/ayojs/ayo/blob/latest/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src